### PR TITLE
add validation help message in response

### DIFF
--- a/src/main/java/foo/bar/springfunctionalwebvalidation/controller/RequestHandler.java
+++ b/src/main/java/foo/bar/springfunctionalwebvalidation/controller/RequestHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
 import javax.validation.Validator;
+import java.io.Serializable;
 import java.util.function.Function;
 
 @Component
@@ -26,7 +27,36 @@ public class RequestHandler {
                 .flatMap(
                         body -> validator.validate(body).isEmpty()
                                 ? block.apply(Mono.just(body))
-                                : ServerResponse.unprocessableEntity().build()
+                                : ServerResponse.unprocessableEntity()
+                                .syncBody(validator.validate(body)
+                                        .stream()
+                                        .map(v -> new Result(v.getPropertyPath().toString(), v.getMessage())))
                 );
+    }
+}
+
+class Result implements Serializable {
+    private String field;
+    private String message;
+
+    public Result(String field, String message) {
+        this.field = field;
+        this.message = message;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 }


### PR DESCRIPTION
With this changes when the query is wrong the response 422 can look more explicit:
```
[
  {
    "field": "author",
    "message": "must not be empty"
  },
  {
    "field": "title",
    "message": "must not be empty"
  }
]
```

